### PR TITLE
Update removeItem spec

### DIFF
--- a/test/spec/arraysPracticeSpec.js
+++ b/test/spec/arraysPracticeSpec.js
@@ -139,7 +139,7 @@ describe('arraysPractice', function () {
 			expect(removeItem).toEqual(jasmine.any(Function));
 		})
 		it('should return an array', function () {
-			expect(removeItem()).toEqual(jasmine.any(Array));
+			expect(removeItem([])).toEqual(jasmine.any(Array));
 		})
 		it('should remove an item from a groceryList array (if it is in the array)', function () {
 			var groceryList = ['chips', 'soda', 'celery', 'pizza'];


### PR DESCRIPTION
removeItem spec for returning an array was requiring an array to be passed in, this was breaking some tests that probably should have passed.